### PR TITLE
Fixed small issue regarding inconsistencies between types and moved to int16_t

### DIFF
--- a/src/ESPping.cpp
+++ b/src/ESPping.cpp
@@ -17,6 +17,7 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 #include "ESPping.h"
+#include <stdint.h>
 
 #ifdef ESP8266
 extern "C" void esp_schedule();
@@ -29,7 +30,7 @@ extern "C" void esp_yield(void) {};
 
 PingClass::PingClass() {}
 
-bool PingClass::ping(IPAddress dest, unsigned int count) {
+bool PingClass::ping(IPAddress dest, int16_t count) {
     _expected_count = count;
     _errors = 0;
     _success = 0;
@@ -68,7 +69,7 @@ bool PingClass::ping(IPAddress dest, unsigned int count) {
     return (_success > 0);
 }
 
-bool PingClass::ping(const char* host, unsigned int count) {
+bool PingClass::ping(const char* host, int16_t count) {
     IPAddress remote_addr;
 
     if (WiFi.hostByName(host, remote_addr))

--- a/src/ESPping.h
+++ b/src/ESPping.h
@@ -49,8 +49,8 @@ class PingClass {
   public:
     PingClass();
 
-    bool ping(IPAddress dest,   uint16_t count = 5);
-    bool ping(const char* host, uint16_t count = 5);
+    bool ping(IPAddress dest,   int16_t count = 5);
+    bool ping(const char* host, int16_t count = 5);
 
     float averageTime();
     uint minTime();

--- a/src/ESPping.h
+++ b/src/ESPping.h
@@ -20,6 +20,7 @@
 #ifndef ESPping_H
 #define ESPping_H
 
+#include <stdint.h>
 #include <Arduino.h>
 #ifdef ESP32
 #include <WiFi.h>

--- a/src/ESPping.h
+++ b/src/ESPping.h
@@ -49,8 +49,8 @@ class PingClass {
   public:
     PingClass();
 
-    bool ping(IPAddress dest,   unsigned int count = 5);
-    bool ping(const char* host, unsigned int count = 5);
+    bool ping(IPAddress dest,   uint16_t count = 5);
+    bool ping(const char* host, uint16_t count = 5);
 
     float averageTime();
     uint minTime();

--- a/src/ping32.cpp
+++ b/src/ping32.cpp
@@ -244,7 +244,7 @@ static void stop_action(int i) {
 * Operation functions
 *
 */
-void ping(const char *name, int count, int interval, int size, int timeout) {
+void ping(const char *name, int16_t count, int interval, int size, int timeout) {
     // Resolve name
     hostent * target = gethostbyname(name);
     IPAddress adr = *target->h_addr_list[0];
@@ -261,7 +261,7 @@ bool ping_start(struct ping_option *ping_o) {
     return ping_start(ping_o->ip,ping_o->count,0,0,0,ping_o);
 
 }
-bool ping_start(IPAddress adr, int count=0, int interval=0, int size=0, int timeout=0, struct ping_option *ping_o) {
+bool ping_start(IPAddress adr, int16_t count=0, int interval=0, int size=0, int timeout=0, struct ping_option *ping_o) {
 //	driver_error_t *error;
     struct sockaddr_in address;
     ip4_addr_t ping_target;

--- a/src/ping32.h
+++ b/src/ping32.h
@@ -9,7 +9,7 @@ typedef void(*ping_recv_function)(void* arg, void *pdata);
 typedef void(*ping_sent_function)(void* arg, void *pdata);
 
 struct ping_option {
-    uint32_t count;
+    int16_t count;
     uint32_t ip;
     uint32_t coarse_time;
     ping_recv_function recv_function;
@@ -29,8 +29,8 @@ struct ping_resp {
 };
 
 bool ping_start(struct ping_option *ping_opt);
-void ping(const char *name, int count, int interval, int size, int timeout);
-bool ping_start(IPAddress adr, int count, int interval, int size, int timeout, struct ping_option *ping_o = NULL);
+void ping(const char *name, int16_t count, int interval, int size, int timeout);
+bool ping_start(IPAddress adr, int16_t count, int interval, int size, int timeout, struct ping_option *ping_o = NULL);
 
 #endif
 #endif // PING_H

--- a/src/ping32.h
+++ b/src/ping32.h
@@ -4,6 +4,7 @@
 #define PING32_H
 
 #include <Arduino.h>
+#include <stdint.h>
 
 typedef void(*ping_recv_function)(void* arg, void *pdata);
 typedef void(*ping_sent_function)(void* arg, void *pdata);


### PR DESCRIPTION
Why` int16_t`?
- 32 thousand is way more than enough pings and the benefits of having a signed int outweigh those that come from having double the max as no one will use it
- I am aware that some compilers turn int to int16 by default but this solution works on everything
- int8_t or uint8_t _could_ be used, but I chose not to because they don't provide much headroom.

I haven't done much testing but it fixed my issue and seems stable. I would appreciate if someone else tested if it works